### PR TITLE
Allow "on"/"off" string for `getboolcoerce`

### DIFF
--- a/src/ini.rs
+++ b/src/ini.rs
@@ -374,8 +374,8 @@ impl Ini {
     }
 
     ///Parses the stored value from the key stored in the defined section to a `bool`. For ease of use, the function converts the type coerces a match.
-    ///It attempts to case-insenstively find `true`, `yes`, `t`, `y` and `1` to parse it as `True`.
-    ///Similarly it attempts to case-insensitvely find `false`, `no`, `f`, `n` and `0` to parse it as `False`.
+    ///It attempts to case-insenstively find `true`, `yes`, `t`, `y`, `1` and `on` to parse it as `True`.
+    ///Similarly it attempts to case-insensitvely find `false`, `no`, `f`, `n`, `0` and `off` to parse it as `False`.
     ///## Example
     ///```rust
     ///use configparser::ini::Ini;
@@ -394,9 +394,9 @@ impl Ini {
                 Some(val) => match val {
                     Some(inner) => {
                         let boolval = &inner.to_lowercase()[..];
-                        if ["true", "yes", "t", "y", "1"].contains(&boolval) {
+                        if ["true", "yes", "t", "y", "1", "on"].contains(&boolval) {
                             Ok(Some(true))
-                        } else if ["false", "no", "f", "n", "0"].contains(&boolval) {
+                        } else if ["false", "no", "f", "n", "0", "off"].contains(&boolval) {
                             Ok(Some(false))
                         } else {
                             Err(format!(


### PR DESCRIPTION
This PR:
  * Allows "on" or "off" string for `getboolcoerce` function.
 
As far as I know, there is no spec for INI files, but some implementations such as [Python](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.getboolean) or [PHP](https://www.php.net/manual/en/function.parse-ini-file.php) permits "on" and "off" value for boolean type. I think it's worth supporting these strings on this crate.